### PR TITLE
Failure to link lib on a ARM platform

### DIFF
--- a/cmake/lua-cjson-2_1_0.patch
+++ b/cmake/lua-cjson-2_1_0.patch
@@ -20,7 +20,7 @@ diff -Naur lua-cjson-2.1.0.orig/CMakeLists.txt lua-cjson-2_1_0/CMakeLists.txt
  
  if(NOT USE_INTERNAL_FPCONV)
      # Use libc number conversion routines (strtod(), sprintf())
-@@ -50,27 +44,32 @@
+@@ -50,27 +44,33 @@
      add_definitions(-DUSE_INTERNAL_ISINF)
  endif()
  


### PR DESCRIPTION
Hi,

Came across issues building latest version of heka due to issue with cjson not compiled with fpic. Added additional compiler flags to the cjson patch fixed this.

Error encountered:

 [100%] Built target mocks
 Scanning dependencies of target hekad
 # github.com/mozilla-services/heka/sandbox/lua
 /usr/bin/ld.bfd.real: /usr/local/src/golang/heka/build/heka/lib/libcjson.a(strbuf.c.o): relocation  R_ARM_THM_MOVW_ABS_NC against `stderr' can not be used when making a shared object;    recompile with -fPIC
 /usr/local/src/golang/heka/build/heka/lib/libcjson.a: could not read symbols: Bad value
 collect2: ld returned 1 exit status
 make[2]: **\* [CMakeFiles/hekad] Error 2
 make[1]: **\* [CMakeFiles/hekad.dir/all] Error 2
 make: **\* [all] Error 2
