### PR TITLE
Create an empty metatable for user modules

### DIFF
--- a/src/lua_sandbox_private.c
+++ b/src/lua_sandbox_private.c
@@ -375,6 +375,9 @@ int require_library(lua_State* lua)
     if (luaL_dofile(lua, fn) != 0) {
       luaL_error(lua, "%s", lua_tostring(lua, -1));
     }
+    // Add an empty metatable to identify the library during preservation.
+    lua_newtable(lua);
+    lua_setmetatable(lua, -2);
   }
   lua_pushvalue(lua, -1);
   lua_setfield(lua, pos, name);

--- a/src/test/lua/serialize.lua
+++ b/src/test/lua/serialize.lua
@@ -3,6 +3,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 require "circular_buffer"
+util = require "util"
 
 count = 0
 rate = 0.12345678

--- a/src/test/output/serialize.lua51.data
+++ b/src/test/output/serialize.lua51.data
@@ -1,3 +1,4 @@
+_G["_VERSION"] = "Lua 5.1"
 if _G["dataRef"] == nil then _G["dataRef"] = circular_buffer.new(3, 3, 1) end
 _G["dataRef"]:set_header(1, "Column_1", "count", "sum")
 _G["dataRef"]:set_header(2, "Column_2", "count", "sum")
@@ -66,6 +67,5 @@ _G["nested"]["cb"]:set_header(4, "Column_4", "count", "sum")
 _G["nested"]["cb"]:set_header(5, "Column_5", "count", "sum")
 _G["nested"]["cb"]:set_header(6, "Column_6", "count", "sum")
 _G["nested"]["cb"]:fromstring("1 1 nan nan nan nan nan nan nan nan nan nan nan nan")
-_G["_VERSION"] = "Lua 5.1"
 _G["rates"] = _G["kvp"]["r"]
 _G["count"] = 0

--- a/src/test/test_lua_sandbox.c
+++ b/src/test/test_lua_sandbox.c
@@ -1018,7 +1018,7 @@ static char* benchmark_serialize()
 
   clock_t t = clock();
   for (int x = 0; x < iter; ++x) {
-    lua_sandbox* sb = lsb_create(NULL, "lua/serialize.lua", "../../modules", 32767, 1000,
+    lua_sandbox* sb = lsb_create(NULL, "lua/serialize.lua", "../../modules", 64000, 1000,
                                  1024);
     mu_assert(sb, "lsb_create() received: NULL");
 
@@ -1041,7 +1041,7 @@ static char* benchmark_deserialize()
 
   clock_t t = clock();
   for (int x = 0; x < iter; ++x) {
-    lua_sandbox* sb = lsb_create(NULL, "lua/serialize.lua", "../../modules", 32767, 1000,
+    lua_sandbox* sb = lsb_create(NULL, "lua/serialize.lua", "../../modules", 64000, 1000,
                                  1024);
     mu_assert(sb, "lsb_create() received: NULL");
 


### PR DESCRIPTION
If a user module is loaded into a global variable the preservation
will restore it to an empty table, wiping out the real module.
