### PR TITLE
remove unused variable 'seconds_in_minute'

### DIFF
--- a/src/lua_circular_buffer.c
+++ b/src/lua_circular_buffer.c
@@ -26,7 +26,6 @@ const char* lsb_circular_buffer_table = "circular_buffer";
 #define COLUMN_NAME_SIZE 16
 #define UNIT_LABEL_SIZE 8
 
-static const time_t seconds_in_minute = 60;
 static const time_t seconds_in_day = 60 * 60 * 24;
 
 static const char* column_aggregation_methods[] = { "sum", "min", "max", "none",


### PR DESCRIPTION
Hi,

When building Heka on OSX (clang 3.4), I get the following error:

```
[ 93%] Building C object src/CMakeFiles/luasandbox.dir/lua_circular_buffer.c.o
/Users/bartleusink/heka/build/ep_base/Source/lua_sandbox/src/lua_circular_buffer.c:29:21: error: unused variable 'seconds_in_minute'
      [-Werror,-Wunused-const-variable]
static const time_t seconds_in_minute = 60;
                    ^
1 error generated.
make[5]: *** [src/CMakeFiles/luasandbox.dir/lua_circular_buffer.c.o] Error 1
make[4]: *** [src/CMakeFiles/luasandbox.dir/all] Error 2
make[3]: *** [all] Error 2
make[2]: *** [ep_base/Stamp/lua_sandbox/lua_sandbox-build] Error 2
make[1]: *** [CMakeFiles/lua_sandbox.dir/all] Error 2
make: *** [all] Error 2
```

This PR removes the unused variable 'seconds_in_minute'
