### PR TITLE
Fix the circular buffer 'get' beyond the end of the buffer

### DIFF
--- a/src/lua_circular_buffer.c
+++ b/src/lua_circular_buffer.c
@@ -195,7 +195,8 @@ static int check_row(circular_buffer* cb, double ns, int advance)
     clear_rows(cb, row_delta);
     cb->current_time = t;
     cb->current_row = row;
-  } else if (abs(row_delta) >= (int)cb->rows) {
+  } else if (requested_row > current_row
+             || abs(row_delta) >= (int)cb->rows) {
     return -1;
   }
   return row;

--- a/src/test/lua/circular_buffer.lua
+++ b/src/test/lua/circular_buffer.lua
@@ -169,7 +169,7 @@ function report(tc)
         end
     elseif tc == 8 then
         local cb = circular_buffer.new(20,1,1)
-        u, p = cb:mannwhitneyu(1, 1e9, 10e9, 11e9, 20e9)
+        u, p = cb:mannwhitneyu(1, 0e9, 9e9, 10e9, 19e9)
         if u ~= 0 or math.floor(p * 100000) ~=  9 then
             error(string.format("u is %g p is %g", u, p))
         end
@@ -234,5 +234,10 @@ function report(tc)
         assert(n == args[1], "invalid name")
         assert(u == args[2], "invalid unit")
         assert(m == args[3], "invalid aggregation_method")
+    elseif tc == 16 then
+        local cb = circular_buffer.new(10,1,1)
+        assert(not cb:get(10*1e9, 1), "value found beyond the end of the buffer")
+        cb:set(20*1e9, 1, 1)
+        assert(not cb:get(10*1e9, 1), "value found beyond the start of the buffer")
     end
 end

--- a/src/test/test_lua_sandbox.c
+++ b/src/test/test_lua_sandbox.c
@@ -601,7 +601,7 @@ static char* test_cbuf()
   mu_assert(strcmp(outputs[3], written_data) == 0, "received: %s",
             written_data);
 
-  for (int i = 1; i < 16; ++i) {
+  for (int i = 1; i < 17; ++i) {
     result = report(sb, i);
     mu_assert(result == 0, "report() test: %d received: %d error: %s", i, result, lsb_get_error(sb));
   }


### PR DESCRIPTION
It now returns nil as specified instead of wrapping around to the
beginning of the buffer.
