### PR TITLE
Correct the MySQL slow query grammar

### DIFF
--- a/modules/mysql.lua
+++ b/modules/mysql.lua
@@ -5,51 +5,41 @@
 -- Imports
 local l = require "lpeg"
 l.locale(l)
-local ip = require "ip_address"
 local tonumber = tonumber
 
 local M = {}
 setfenv(1, M) -- Remove external access to contain everything in the module
 
-local space     = l.space^1
-local sep       = l.P("\n")
-local line      = (l.P(1) - sep)^0 * sep
-local float     = l.digit^1 * "." * l.digit^1
+local space         = l.space^1
+local sep           = l.P"\n"
+local sql_end       = l.P";\n"
+local line          = (l.P(1) - sep)^0 * sep
+local float         = l.digit^1 * "." * l.digit^1
 
-local time_5_5      = l.P"# Time: " * l.digit^1 * l.space * l.digit * l.digit * ":" * l.digit * l.digit * ":" * l.digit * l.digit * sep
+local time          = l.P"# Time: " * line
 
-local ip_address    = ip.v4 + ip.v6
 local user_name     = l.alpha^1 * "[" * l.alpha^1 * "]"
-local host_name     = l.alpha^0 * l.space^0 * "[" * l.Cg(ip_address^0, "Hostname") * "]"
+local host_name     = l.alpha^0 * l.space^0 * "[" * l.Cg((l.P(1) - "]")^1, "Hostname") * "]"
 local user          = l.P"# User@Host: " * user_name * space * "@" * space * host_name * sep
-
-local thread_id     = l.P"# Thread_id: " * l.digit^1
-local schema        = l.P"Schema: " * l.Cg(l.alnum^0, "Schema")
-local last_errno    = l.P"Last_errno: " * l.digit^1
-local killed        = l.P"Killed: " * l.digit^1
-local thread        = thread_id * space * schema * space * l.Cg(last_errno / tonumber, "Last_errno") * space * killed * sep
 
 local query_time    = l.P"# Query_time: " * l.Cg(l.Ct(l.Cg(float / tonumber, "value") * l.Cg(l.Cc"s", "representation")), "Query_time")
 local lock_time     = l.P"Lock_time: " * l.Cg(l.Ct(l.Cg(float / tonumber, "value") * l.Cg(l.Cc"s", "representation")), "Lock_time")
 local rows_sent     = l.P"Rows_sent: " * l.Cg(l.digit^1 / tonumber, "Rows_sent")
 local rows_examined = l.P"Rows_examined: " * l.Cg(l.digit^1 / tonumber, "Rows_examined")
-local rows_affected = l.P"Rows_affected: " * l.Cg(l.digit^1 / tonumber, "Rows_affected")
-local rows_read     = l.P"Rows_read: " * l.Cg(l.digit^1 / tonumber, "Rows_read")
-local query_5_1     = query_time * space * lock_time * space * rows_sent * space * rows_examined * space * rows_affected * space * rows_read * sep
-local query_5_5     = query_time * space * lock_time * space * rows_sent * space * rows_examined * sep
+local query         = l.Ct(query_time * space * lock_time * space * rows_sent * space * rows_examined * sep)
 
-local bytes_sent        = l.P"# Bytes_sent: " * l.Cg(l.Ct(l.Cg(l.digit^1 / tonumber, "value") * l.Cg(l.Cc"B", "representation")), "Bytes_sent")
-local tmp_tables        = l.P"Tmp_tables: " * l.Cg(l.digit^1 / tonumber, "Tmp_tables")
-local tmp_disk_tables   = l.P"Tmp_disk_tables: " * l.Cg(l.digit^1 / tonumber, "Tmp_disk_tables")
-local tmp_table_sizes   = l.P"Tmp_table_sizes: " * l.Cg(l.digit^1 / tonumber, "Tmp_table_sizes")
-local bytes             =  bytes_sent * space * tmp_tables * space * tmp_disk_tables * space * tmp_table_sizes * sep
+local use_db        = l.P"use " * line
 
-local inno_db   = l.P"# InnoDB" * line
-local use_db    = l.P"use " * line
-local timestamp = l.P"SET timestamp=" * l.Cg((l.digit^1 / "%0000000000"), "Timestamp") * line
-local sql       = l.Cg((l.P(1))^0, "Payload")
+local last_insert   = l.P"last_insert_id=" * l.digit^1 * ","
+local insert        = l.P"insert_id=" * l.digit^1 * ","
+local timestamp     = l.P"timestamp=" * l.Cg((l.digit^1 / "%0000000000"), "Timestamp")
+local set           = l.P"SET " * last_insert^0 * insert^0 * timestamp * ";" * sep
 
-slow_query_grammar_5_1 = l.Ct(user * l.Cg(l.Ct(thread * query_5_1 * bytes), "Fields") * inno_db^0 * use_db^0 * timestamp * sql)
-slow_query_grammar_5_5 = l.Ct(time_5_5 * user * l.Cg(l.Ct(query_5_5), "Fields") * timestamp * sql)
+local admin         = l.P"# administrator command: " * line
+
+local sql           = l.Cg((l.P(1) - sql_end)^0 * sql_end, "Payload")
+
+slow_query_grammar          = l.Ct(time^0 * user *  l.Cg(query, "Fields") * use_db^0 * set * admin^0 * sql)
+short_slow_query_grammar    = l.Ct(l.Cg(query, "Fields") * use_db^0 * set * admin^0 * sql)
 
 return M

--- a/src/test/test_lua_sandbox.c
+++ b/src/test/test_lua_sandbox.c
@@ -877,7 +877,7 @@ static char* test_lpeg_mysql()
   int result = lsb_init(sb, NULL);
   mu_assert(result == 0, "lsb_init() received: %d %s", result, lsb_get_error(sb));
 
-  for (int i = 0; i < 2; ++i) {
+  for (int i = 0; i < 3; ++i) {
     result = process(sb, i);
     mu_assert(result == 0, "process() received: %d %s", result, lsb_get_error(sb));
   }


### PR DESCRIPTION
This version of the parser was built based on the MySQL source in sql/log.cc
(5.1 and 5.5 have the same format).  Moral of the story, only trust the source
code because the initial sample output provided was actually a
Percona-Server-server-51-5.1.58 slow query log and second sample output was a
MySQL 5.1 slow query log.
