### PR TITLE
Add sandbox preservation versioning

### DIFF
--- a/include/lua_sandbox.h
+++ b/include/lua_sandbox.h
@@ -78,7 +78,14 @@ LSB_EXPORT lua_sandbox* lsb_create(void* parent,
  *
  * @param lsb Pointer to the sandbox.
  * @param state_file Filename where the global data is read. Use a NULL or empty
- *                   string no data restoration.
+ *                   string for no data restoration.  The global
+ *                   _PRESERVATION_VERSION variable will be examined during
+ *                   restoration; if the previous version does not match the
+ *                   current version the restoration will be aborted and the
+ *                   sandbox will start cleanly. _PRESERVATION_VERSION should be
+ *                   incremented any time an incompatible change is made to the
+ *                   global data schema. If no version is set the check will
+ *                   always succeed and a version of zero is assigned.
  *
  * @return int Zero on success, non-zero on failure.
  */

--- a/src/test/lua/restore.lua
+++ b/src/test/lua/restore.lua
@@ -1,0 +1,19 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+_PRESERVATION_VERSION = 1
+
+count = 100
+
+function process()
+    count = count + 1
+    write_output(count)
+    return 0
+end
+
+
+function report(ns)
+    _PRESERVATION_VERSION = ns
+end
+
+

--- a/src/test/output/serialize.lua51.data
+++ b/src/test/output/serialize.lua51.data
@@ -1,3 +1,4 @@
+if _PRESERVATION_VERSION and _PRESERVATION_VERSION ~= 0 then return end
 _G["_VERSION"] = "Lua 5.1"
 if _G["dataRef"] == nil then _G["dataRef"] = circular_buffer.new(3, 3, 1) end
 _G["dataRef"]:set_header(1, "Column_1", "count", "sum")


### PR DESCRIPTION
The versioning will allow the developer to specify when it is not
safe to restore preserved data.
