### PR TITLE
Issue #13 Grammar memory usage

### DIFF
--- a/modules/ip_address.lua
+++ b/modules/ip_address.lua
@@ -19,7 +19,6 @@ v4          = d8 * "." * d8 * "." * d8 * "." * d8
 
 local h16   = l.xdigit * l.xdigit^-3
 local hg    = h16 * ":"
-local hgs   = hg - (h16 * "::")
 local ls32  = hg * h16
             + v4
 


### PR DESCRIPTION
Refactor the grammar to reduce its memory footprint.  Decreases max
usage by about 300KiB and the final grammar size by ~50KiB
