### PR TITLE
Add user agent detection for Edge

### DIFF
--- a/modules/common_log_format.lua
+++ b/modules/common_log_format.lua
@@ -334,7 +334,8 @@ local ua_os_matchers = {
 }
 
 local ua_browser_matchers = {
-      {"Chrome"        , ua_keyword("Chrome/")}
+      {"Edge"          , ua_keyword("Edge/")}
+    , {"Chrome"        , ua_keyword("Chrome/")}
     , {"Opera Mini"    , ua_basic}
     , {"Opera Mobi"    , ua_basic}
     , {"Opera"         , ua_basic}


### PR DESCRIPTION
Detects Microsoft's Edge browser in the user agent field. I tested this against the following user agent string which came from using a Windows 10/Edge version 12 machine in Browserstack.

```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240
```