### PR TITLE
support building with gcc 5

### DIFF
--- a/src/heka/rapidjson.cpp
+++ b/src/heka/rapidjson.cpp
@@ -485,7 +485,7 @@ static int hj_parse_message(lua_State *lua)
   lsb_lua_sandbox *lsb = static_cast<lsb_lua_sandbox *>
       (lua_touserdata(lua, lua_upvalueindex(1)));
   if (!lsb) {
-    return luaL_error(lua, "%s() invalid lightuserdata", __FUNCTION__);
+    return luaL_error(lua, "%s() invalid lightuserdata", __func__);
   }
   int n = lua_gettop(lua);
   int idx = 1;

--- a/src/heka/sandbox.c
+++ b/src/heka/sandbox.c
@@ -165,7 +165,7 @@ static int inject_payload(lua_State *lua)
 
   lsb_lua_sandbox *lsb = lua_touserdata(lua, lua_upvalueindex(1));
   if (!lsb) {
-    return luaL_error(lua, "%s invalid lightuserdata", __FUNCTION__);
+    return luaL_error(lua, "%s invalid lightuserdata", __func__);
   }
 
   int n = lua_gettop(lua);
@@ -180,14 +180,14 @@ static int inject_payload(lua_State *lua)
   if (n > 0) {
     if (lua_type(lua, 1) != LUA_TSTRING) {
       return luaL_error(lua, "%s() payload_type argument must be a string",
-                        __FUNCTION__);
+                        __func__);
     }
   }
 
   if (n > 1) {
     if (lua_type(lua, 2) != LUA_TSTRING) {
       return luaL_error(lua, "%s() payload_name argument must be a string",
-                        __FUNCTION__);
+                        __func__);
     }
   }
 
@@ -348,19 +348,19 @@ lsb_heka_sandbox* lsb_heka_create_input(void *parent,
                                         lsb_heka_im_input im)
 {
   if (!lua_file) {
-    if (logger) logger(__FUNCTION__, 3, "lua_file must be specified");
+    if (logger) logger(__func__, 3, "lua_file must be specified");
     return NULL;
   }
 
   if (!im) {
-    if (logger) logger(__FUNCTION__, 3, "inject_message callback must be "
+    if (logger) logger(__func__, 3, "inject_message callback must be "
                        "specified");
     return NULL;
   }
 
   lsb_heka_sandbox *hsb = calloc(1, sizeof(lsb_heka_sandbox));
   if (!hsb) {
-    if (logger) logger(__FUNCTION__, 3, "memory allocation failed");
+    if (logger) logger(__func__, 3, "memory allocation failed");
     return NULL;
   }
 
@@ -543,12 +543,12 @@ lsb_heka_sandbox* lsb_heka_create_analysis(void *parent,
                                            lsb_heka_im_analysis im)
 {
   if (!lua_file) {
-    if (logger) logger(__FUNCTION__, 3, "lua_file must be specified");
+    if (logger) logger(__func__, 3, "lua_file must be specified");
     return NULL;
   }
 
   if (!im) {
-    if (logger) logger(__FUNCTION__, 3, "inject_message callback must be "
+    if (logger) logger(__func__, 3, "inject_message callback must be "
                        "specified");
     return NULL;
   }
@@ -556,7 +556,7 @@ lsb_heka_sandbox* lsb_heka_create_analysis(void *parent,
 
   lsb_heka_sandbox *hsb = calloc(1, sizeof(lsb_heka_sandbox));
   if (!hsb) {
-    if (logger) logger(__FUNCTION__, 3, "memory allocation failed");
+    if (logger) logger(__func__, 3, "memory allocation failed");
     return NULL;
   }
 
@@ -626,12 +626,12 @@ lsb_heka_sandbox* lsb_heka_create_output(void *parent,
                                          lsb_heka_update_checkpoint ucp)
 {
   if (!lua_file) {
-    if (logger) logger(__FUNCTION__, 3, "lua_file must be specified");
+    if (logger) logger(__func__, 3, "lua_file must be specified");
     return NULL;
   }
 
   if (!ucp) {
-    if (logger) logger(__FUNCTION__, 3, "update_checkpoint callback must be "
+    if (logger) logger(__func__, 3, "update_checkpoint callback must be "
                        "specified");
     return NULL;
   }
@@ -639,7 +639,7 @@ lsb_heka_sandbox* lsb_heka_create_output(void *parent,
 
   lsb_heka_sandbox *hsb = calloc(1, sizeof(lsb_heka_sandbox));
   if (!hsb) {
-    if (logger) logger(__FUNCTION__, 3, "memory allocation failed");
+    if (logger) logger(__func__, 3, "memory allocation failed");
     return NULL;
   }
 

--- a/src/luasandbox.c
+++ b/src/luasandbox.c
@@ -223,7 +223,7 @@ static lua_State* load_sandbox_config(const char *cfg, lsb_logger logger)
 {
   lua_State *L = luaL_newstate();
   if (!L) {
-    if (logger) logger(__FUNCTION__, 3, "lua_State creation failed");
+    if (logger) logger(__func__, 3, "lua_State creation failed");
     return NULL;
   }
 
@@ -250,7 +250,7 @@ static lua_State* load_sandbox_config(const char *cfg, lsb_logger logger)
 cleanup:
   if (ret) {
     if (logger) {
-      logger(__FUNCTION__, 3, "config error: %s", lua_tostring(L, -1));
+      logger(__func__, 3, "config error: %s", lua_tostring(L, -1));
     }
     lua_close(L);
     return NULL;
@@ -305,7 +305,7 @@ static void copy_table(lua_State *sb, lua_State *cfg, lsb_logger logger)
         break;
       default:
         if (logger) {
-          logger(__FUNCTION__, 4, "skipping config value type: %s",
+          logger(__func__, 4, "skipping config value type: %s",
                  lua_typename(cfg, vt));
         }
         break;
@@ -313,7 +313,7 @@ static void copy_table(lua_State *sb, lua_State *cfg, lsb_logger logger)
       break;
     default:
       if (logger) {
-        logger(__FUNCTION__, 4, "skipping config key type: %s",
+        logger(__func__, 4, "skipping config key type: %s",
                lua_typename(cfg, kt));
       }
       break;
@@ -381,12 +381,12 @@ lsb_lua_sandbox* lsb_create(void *parent,
                             lsb_logger logger)
 {
   if (!lua_file) {
-    if (logger) logger(__FUNCTION__, 3, "lua_file must be specified");
+    if (logger) logger(__func__, 3, "lua_file must be specified");
     return NULL;
   }
 
   if (!set_tz()) {
-    if (logger) logger(__FUNCTION__, 3, "fail to set the TZ to UTC");
+    if (logger) logger(__func__, 3, "fail to set the TZ to UTC");
     return NULL;
   }
 
@@ -394,7 +394,7 @@ lsb_lua_sandbox* lsb_create(void *parent,
 
   lsb_lua_sandbox *lsb = malloc(sizeof*lsb);
   if (!lsb) {
-    if (logger) logger(__FUNCTION__, 3, "memory allocation failed");
+    if (logger) logger(__func__, 3, "memory allocation failed");
     return NULL;
   }
   memset(lsb->usage, 0, sizeof(lsb->usage));
@@ -406,7 +406,7 @@ lsb_lua_sandbox* lsb_create(void *parent,
 #endif
 
   if (!lsb->lua) {
-    if (logger) logger(__FUNCTION__, 3, "lua state creation failed");
+    if (logger) logger(__func__, 3, "lua state creation failed");
     free(lsb);
     return NULL;
   }
@@ -444,7 +444,7 @@ lsb_lua_sandbox* lsb_create(void *parent,
   lsb->state_file = NULL;
 
   if (!lsb->lua_file || lsb_init_output_buffer(&lsb->output, ol)) {
-    if (logger) logger(__FUNCTION__, 3, "memory allocation failed failed");
+    if (logger) logger(__func__, 3, "memory allocation failed failed");
     lsb_free_output_buffer(&lsb->output);
     free(lsb->lua_file);
     lua_close(lsb->lua);

--- a/src/util/heka_message.c
+++ b/src/util/heka_message.c
@@ -205,7 +205,7 @@ bool lsb_decode_heka_message(lsb_heka_message *m,
 {
   if (!m || !buf || len == 0) {
     if (logger) {
-      logger(__FUNCTION__, 4, LSB_ERR_UTIL_NULL);
+      logger(__func__, 4, LSB_ERR_UTIL_NULL);
     }
     return false;
   }
@@ -275,7 +275,7 @@ bool lsb_decode_heka_message(lsb_heka_message *m,
         lsb_heka_field *tmp = realloc(m->fields,
                                       m->fields_size * sizeof(lsb_heka_field));
         if (!tmp) {
-          if (logger) logger(__FUNCTION__, 0, "fields reallocation failed");
+          if (logger) logger(__func__, 0, "fields reallocation failed");
           return false;
         }
         m->fields = tmp;
@@ -294,19 +294,19 @@ bool lsb_decode_heka_message(lsb_heka_message *m,
 
   if (!cp) {
     if (logger) {
-      logger(__FUNCTION__, 4, "tag:%d wiretype:%d position:%d", tag,
+      logger(__func__, 4, "tag:%d wiretype:%d position:%d", tag,
              wiretype, lp - buf);
     }
     return false;
   }
 
   if (!m->uuid.s) {
-    if (logger) logger(__FUNCTION__, 4, "missing " LSB_UUID);
+    if (logger) logger(__func__, 4, "missing " LSB_UUID);
     return false;
   }
 
   if (!timestamp) {
-    if (logger) logger(__FUNCTION__, 4, "missing " LSB_TIMESTAMP);
+    if (logger) logger(__func__, 4, "missing " LSB_TIMESTAMP);
     return false;
   }
 
@@ -324,7 +324,7 @@ bool lsb_find_heka_message(lsb_heka_message *m,
 {
   if (!m || !ib || !discarded_bytes) {
     if (logger) {
-      logger(__FUNCTION__, 4, LSB_ERR_UTIL_NULL);
+      logger(__func__, 4, LSB_ERR_UTIL_NULL);
     }
     return false;
   }


### PR DESCRIPTION
Ran into this trying to build on Fedora 23. From https://gcc.gnu.org/gcc-5/porting_to.html:

"-Wpedantic now warns about non-standard predefined identifiers...The fix is either to use the standard predefined identifier `__func__` (since C99), or to use the `__extension__` keyword:

```c
  const char *s = __extension__ __FUNCTION__;
```
"