### PR TITLE
Use nanosecond precision when generating fresh timestamps (on Linux).

### DIFF
--- a/src/lsb_serialize_protobuf.c
+++ b/src/lsb_serialize_protobuf.c
@@ -613,7 +613,14 @@ int lsb_serialize_table_as_pb(lua_sandbox* lsb, int index)
   if (lua_isnumber(lsb->lua, -1)) {
     ts = (unsigned long long)lua_tonumber(lsb->lua, -1);
   } else {
+#ifdef __linux__
+    struct timespec now;
+    if (clock_gettime(CLOCK_REALTIME, &now) != 0) return 1;
+    ts = (unsigned long long)(now.tv_sec) * 1e9;
+    ts += (unsigned long long)(now.tv_nsec);
+#else
     ts = (unsigned long long)(time(NULL) * 1e9);
+#endif
   }
   lua_pop(lsb->lua, 1); // remove timestamp
 


### PR DESCRIPTION
When the protobuf serializer is converting a Lua table (e.g., the parameter of `inject_message`), it fills in missing `Timestamp` values with the current time. Previously, this called `time(NULL)`, which returns seconds-level precision, and then converted to nanoseconds by padding all the lower-order digits with zeroes (`* 1e9)`.

This PR adds nanoseconds-level precision using `clock_gettime(CLOCK_REALTIME, [...])`) on Linux, leaving the previous behavior on other platforms. I'm open to including more code to handle other platforms, but I don't have a great way to test.

This PR is targeting the `heka` branch, which is an older branch that's [pinned in heka](https://github.com/mozilla-services/heka/blob/dev/cmake/externals.cmake#L19-L25). Work to support this functionality in `master` is being tracked in https://github.com/mozilla-services/lua_sandbox/issues/116.

cc @trink