### PR TITLE
Add a size option to read_message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(luasandbox C CXX)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Generic Lua sandbox for dynamic data analysis")
 set(CPACK_PACKAGE_VERSION_MAJOR 0)
 set(CPACK_PACKAGE_VERSION_MINOR 15)
-set(CPACK_PACKAGE_VERSION_PATCH 1)
+set(CPACK_PACKAGE_VERSION_PATCH 2)
 set(CPACK_PACKAGE_CONTACT "Mike Trinkala <trink@mozilla.com>")
 
 set(CPACK_DEB_COMPONENT_INSTALL ON)

--- a/docs/heka/analysis.md
+++ b/docs/heka/analysis.md
@@ -53,6 +53,7 @@ Provides access to the Heka message data. Note that both fieldIndex and arrayInd
 * variableName (string)
   * framed (returns the Heka message protobuf string including the framing header)
   * raw (returns the Heka message protobuf string)
+  * size (returns the size of the raw Heka message protobuf string)
   * Uuid
   * Type
   * Logger

--- a/src/heka/message.c
+++ b/src/heka/message.c
@@ -988,6 +988,8 @@ int heka_read_message(lua_State *lua, lsb_heka_message *m)
       luaL_addlstring(&b, m->raw.s, m->raw.len);
       luaL_pushresult(&b);
     }
+  } else if (strcmp(field, "size") == 0) {
+    lua_pushnumber(lua, (lua_Number)m->raw.len);
   } else {
     if (field_len >= 8
         && memcmp(field, LSB_FIELDS "[", 7) == 0

--- a/src/heka/test/lua/read_message.lua
+++ b/src/heka/test/lua/read_message.lua
@@ -15,6 +15,7 @@ local tests = {
     {"Severity", 9},
     {"Pid", 0},
     {"raw", 208},
+    {"size", 208},
     {"framed", 214},
     {"Fields[string]", "string"},
     {"Fields[notfound]", nil},
@@ -41,6 +42,8 @@ function process_message()
         local r = read_message(v[1])
         if v[1] == "raw" or v[1] == "framed" then
             assert(v[2] == string.len(r), string.format("test: %d expected: %d received: %d", i, string.len(v[2]), string.len(r)))
+        elseif v[1] == "size" then
+            assert(v[2] == r, string.format("test: %d expected: %d received: %d", i, v[2], r))
         else
             assert(v[2] == r, string.format("test: %d expected: %s received: %s", i, tostring(v[2]), tostring(r)))
         end

--- a/src/util/heka_message.c
+++ b/src/util/heka_message.c
@@ -38,7 +38,7 @@ static size_t decode_header(char *buf, size_t len, size_t max_message_size)
 static const char*
 read_string(int wiretype, const char *p, const char *e, lsb_const_string *s)
 {
-  if (wiretype != 2) {
+  if (wiretype != LSB_PB_WT_LENGTH) {
     return NULL;
   }
 


### PR DESCRIPTION
- quick way to get message stats without copying the entire string to Lua