### PR TITLE
lsb_terminate should not close the lua_State

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(luasandbox VERSION 1.0.2 LANGUAGES C)
+project(luasandbox VERSION 1.0.3 LANGUAGES C)
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Generic Lua sandbox for dynamic data analysis")
 set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})

--- a/cmake/mozsvc.cmake
+++ b/cmake/mozsvc.cmake
@@ -44,7 +44,11 @@ endif()
 
 set(CPACK_PACKAGE_VENDOR        "Mozilla Services")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
-set(CPACK_STRIP_FILES TRUE)
+if(CMAKE_BUILD_TYPE MATCHES "^[Dd][Ee][Bb][Uu][Gg]$")
+    set(CPACK_STRIP_FILES FALSE)
+else()
+    set(CPACK_STRIP_FILES TRUE)
+endif()
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
 include(CPack)

--- a/include/luasandbox.h
+++ b/include/luasandbox.h
@@ -242,7 +242,7 @@ lsb_pcall_setup(lsb_lua_sandbox *lsb, const char *func_name);
 LSB_EXPORT void lsb_pcall_teardown(lsb_lua_sandbox *lsb);
 
 /**
- * Shutdown the sandbox due to a fatal error.
+ * Change the sandbox state to LSB_TERMINATED due to a fatal error.
  *
  * @param lsb Pointer to the sandbox.
  * @param err Reason for termination

--- a/src/luasandbox_serialize.c
+++ b/src/luasandbox_serialize.c
@@ -369,7 +369,7 @@ serialize_kvp(lsb_lua_sandbox *lsb, serialization_data *data, size_t parent)
 lsb_err_value preserve_global_data(lsb_lua_sandbox *lsb)
 {
 
-  if (!lsb->lua || !lsb->state_file) {
+  if (!lsb->lua || !lsb->state_file || lsb->state == LSB_TERMINATED) {
     return NULL;
   }
   lua_sethook(lsb->lua, NULL, 0, 0);

--- a/src/test/test_generic_sandbox.c
+++ b/src/test/test_generic_sandbox.c
@@ -170,6 +170,8 @@ static char* test_api_assertion()
   lsb_add_function(NULL, NULL, NULL);
   lsb_pcall_teardown(NULL);
   lsb_terminate(NULL, NULL);
+  lsb_terminate(sb, NULL);
+  lsb_add_function(sb, lsb_test_write_output, "write_output");
 
   e = lsb_destroy(sb);
   mu_assert(!e, "lsb_destroy() received: %s", e);
@@ -317,8 +319,10 @@ static char* test_usage_error()
 
   mu_assert(sb, "lsb_create() received: NULL");
   lsb_terminate(sb, "forced termination");
+  lsb_state s = lsb_get_state(sb);
+  mu_assert(s == LSB_TERMINATED, "lsb_get_state() received: %d", s);
   u = lsb_usage(sb, LSB_UT_MEMORY, LSB_US_CURRENT);
-  mu_assert(u == 0, "Terminated memory usage received: %" PRIuSIZE, u);
+  mu_assert(u > 0, "Terminated memory usage received: 0");
 
   e = lsb_destroy(sb);
   mu_assert(!e, "lsb_destroy() received: %s", e);

--- a/src/util/test/test_util.c
+++ b/src/util/test/test_util.c
@@ -103,7 +103,7 @@ static char* benchmark_lsb_get_timestamp()
   printf("benchmark_lsb_get_timestamp(%d) - clock %g seconds\n", iter,
          (double)t / CLOCKS_PER_SEC / iter);
   long long delta = lsb_get_timestamp() / 1000000000LL - time(NULL);
-  mu_assert(delta > 0 ? delta < 1 : delta > -1, "delta %lld", delta);
+  mu_assert(delta > 0 ? delta <= 1 : delta >= -1, "delta %lld", delta);
   return NULL;
 }
 


### PR DESCRIPTION
This avoids some race conditions when the sandbox is used by a
threaded host, instead everything is cleaned up in destroy.