### PR TITLE
Don't set TZ to UTC in lsb_create

### DIFF
--- a/src/luasandbox.c
+++ b/src/luasandbox.c
@@ -432,13 +432,6 @@ lsb_lua_sandbox* lsb_create(void *parent,
     return NULL;
   }
 
-  if (!lsb_set_tz(NULL)) {
-    if (logger && logger->cb) {
-      logger->cb(logger->context, __func__, 3, "fail to set the TZ to UTC");
-    }
-    return NULL;
-  }
-
   set_random_seed();
 
   lsb_lua_sandbox *lsb = calloc(1, sizeof(*lsb));


### PR DESCRIPTION
This prevents using any other timezone.

With lua, one can force UTC with os.date("!" .. date_format).